### PR TITLE
Add options to control bold font in statusbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ set -g @tmux-dotbar-fg-session "#9399b2"
 set -g @tmux-dotbar-fg-prefix "#cba6f7"
 ```
 
+You can also set `@tmux-dotbar-bold-status` to use bold font in the statusbar, or `@tmux-dotbar-bold-current-window` to use bold font just for the present (active) window.
+
 ### Status bar
 You may feel the right part a bit empty. If you want, there's an option to display the current time there, you can enable it (disabled by default) in your `.tmux.conf`:
 ```
@@ -89,6 +91,8 @@ set -g @tmux-dotbar-window-status-format " #W "
 set -g @tmux-dotbar-window-status-separator " • "
 set -g @tmux-dotbar-maximized-icon "󰊓"
 set -g @tmux-dotbar-show-maximized-icon-for-all-tabs false
+set -g @tmux-dotbar-bold-status true
+set -g @tmux-dotbar-bold-current-window false
 ```
 
 ## Recommended tmux options

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ tmux dotbar is a simple and minimalist status bar theme for tmux. <br>
 ## Features
 * Icon indicator when a pane is maximized in a window
 * Color indication when tmux prefix is pressed
+* Bell and activity notifications properly displayed with custom styles
 
 ## Installation
 ### TPM (recommended)

--- a/dotbar.tmux
+++ b/dotbar.tmux
@@ -66,9 +66,14 @@ tmux set-option -g window-status-style "bg=${bg},fg=${fg}"
 tmux set-option -g window-status-format "$window_status_format"
 "$show_maximized_icon_for_all_tabs" && tmux set-option -g window-status-format "${window_status_format}#{?window_zoomed_flag,${maximized_pane_icon},}"
 
-# Conditionally apply bold to window-status-current-format
+# Set bell and activity styles that work with the theme
+tmux set-option -g window-status-bell-style "bg=${fg_prefix},fg=${bg},bold"
+tmux set-option -g window-status-activity-style "bg=${fg_current},fg=${bg}"
+
+# Conditionally apply bold to window-status-current-format, respecting bell/activity notifications
 if [ "$bold_current_window" = true ]; then
-  tmux set-option -g window-status-current-format "#[bg=${bg},fg=${fg_current},bold]${window_status_format}#[fg=#39BAE6,bg=${bg}]#{?window_zoomed_flag,${maximized_pane_icon},}#[fg=${bg},bg=default]"
+  # Use conditionals to respect bell and activity states, with bold as default for current window
+  tmux set-option -g window-status-current-format "#{?#{||:#{window_bell_flag},#{window_activity_flag}},#[default],#[bg=${bg},fg=${fg_current},bold]}${window_status_format}#[fg=#39BAE6,bg=${bg}]#{?window_zoomed_flag,${maximized_pane_icon},}#[fg=${bg},bg=default]"
 else
-  tmux set-option -g window-status-current-format "#[bg=${bg},fg=${fg_current}]${window_status_format}#[fg=#39BAE6,bg=${bg}]#{?window_zoomed_flag,${maximized_pane_icon},}#[fg=${bg},bg=default]"
+  tmux set-option -g window-status-current-format "#{?#{||:#{window_bell_flag},#{window_activity_flag}},#[default],#[bg=${bg},fg=${fg_current}]}${window_status_format}#[fg=#39BAE6,bg=${bg}]#{?window_zoomed_flag,${maximized_pane_icon},}#[fg=${bg},bg=default]"
 fi

--- a/dotbar.tmux
+++ b/dotbar.tmux
@@ -21,11 +21,21 @@ fg_current=$(get_tmux_option "@tmux-dotbar-fg-current" '#BFBDB6')
 fg_session=$(get_tmux_option "@tmux-dotbar-fg-session" '#565B66')
 fg_prefix=$(get_tmux_option "@tmux-dotbar-fg-prefix" '#95E6CB')
 
+# bold options
+bold_status=$(get_tmux_option "@tmux-dotbar-bold-status" false)
+bold_current_window=$(get_tmux_option "@tmux-dotbar-bold-current-window" false)
+
 status=$(get_tmux_option "@tmux-dotbar-position" "bottom")
 justify=$(get_tmux_option "@tmux-dotbar-justify" "absolute-centre")
 
 left_state=$(get_tmux_option "@tmux-dotbar-left" true)
-status_left=$("$left_state" && get_tmux_option "@tmux-dotbar-status-left" "#[bg=$bg,fg=$fg_session]#{?client_prefix,, #S }#[bg=$fg_prefix,fg=$bg,bold]#{?client_prefix, #S ,}#[bg=$bg,fg=${fg_session}]")
+
+# Conditionally apply 'nobold' if @tmux-dotbar-bold-status is true
+if [ "$bold_status" = true ]; then
+  status_left=$("$left_state" && get_tmux_option "@tmux-dotbar-status-left" "#[bg=$bg,fg=$fg_session]#{?client_prefix,, #S }#[bg=$fg_prefix,fg=$bg,nobold]#{?client_prefix, #S ,}#[bg=$bg,fg=${fg_session}]")
+else
+  status_left=$("$left_state" && get_tmux_option "@tmux-dotbar-status-left" "#[bg=$bg,fg=$fg_session]#{?client_prefix,, #S }#[bg=$fg_prefix,fg=$bg,bold]#{?client_prefix, #S ,}#[bg=$bg,fg=${fg_session}]")
+fi
 
 right_state=$(get_tmux_option "@tmux-dotbar-right" false)
 status_right=$("$right_state" && get_tmux_option "@tmux-dotbar-status-right" "#[bg=$bg,fg=$fg_session] %H:%M #[bg=$bg,fg=${fg_session}]")
@@ -37,7 +47,14 @@ maximized_pane_icon=$(get_tmux_option "@tmux-dotbar-maximized-icon" '󰊓')
 show_maximized_icon_for_all_tabs=$(get_tmux_option "@tmux-dotbar-show-maximized-icon-for-all-tabs" false)
 
 tmux set-option -g status-position "$status"
-tmux set-option -g status-style "bg=${bg},fg=${fg}"
+
+# Conditionally apply bold to status-style
+if [ "$bold_status" = true ]; then
+  tmux set-option -g status-style "bg=${bg},fg=${fg},bold"
+else
+  tmux set-option -g status-style "bg=${bg},fg=${fg}"
+fi
+
 tmux set-option -g status-justify "$justify"
 
 tmux set-option -g status-left "$status_left"
@@ -49,4 +66,9 @@ tmux set-option -g window-status-style "bg=${bg},fg=${fg}"
 tmux set-option -g window-status-format "$window_status_format"
 "$show_maximized_icon_for_all_tabs" && tmux set-option -g window-status-format "${window_status_format}#{?window_zoomed_flag,${maximized_pane_icon},}"
 
-tmux set-option -g window-status-current-format "#[bg=${bg},fg=${fg_current}]${window_status_format}#[fg=#39BAE6,bg=${bg}]#{?window_zoomed_flag,${maximized_pane_icon},}#[fg=${bg},bg=default]"
+# Conditionally apply bold to window-status-current-format
+if [ "$bold_current_window" = true ]; then
+  tmux set-option -g window-status-current-format "#[bg=${bg},fg=${fg_current},bold]${window_status_format}#[fg=#39BAE6,bg=${bg}]#{?window_zoomed_flag,${maximized_pane_icon},}#[fg=${bg},bg=default]"
+else
+  tmux set-option -g window-status-current-format "#[bg=${bg},fg=${fg_current}]${window_status_format}#[fg=#39BAE6,bg=${bg}]#{?window_zoomed_flag,${maximized_pane_icon},}#[fg=${bg},bg=default]"
+fi


### PR DESCRIPTION
Pretty self-explanatory:

```
set -g @tmux-dotbar-bold-status true           # bold all statusbar text
set -g @tmux-dotbar-bold-current-window false  # bold the active window
```

Added short note in the readme.