### PR TITLE
feat: add rounded prefix highlight option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ set -g @tmux-dotbar-fg-prefix "#cba6f7"
 
 You can also set `@tmux-dotbar-bold-status` to use bold font in the statusbar, or `@tmux-dotbar-bold-current-window` to use bold font just for the active window.
 
+### Rounded prefix highlight
+When the tmux prefix is pressed, the session indicator highlights. By default the edges are square. To use rounded (powerline) edges instead:
+```
+set -g @tmux-dotbar-rounded true
+```
+
 ### Status bar
 You may feel the right part a bit empty. If you want, there's an option to display the current time there, you can enable it (disabled by default) in your `.tmux.conf`:
 ```
@@ -135,6 +141,7 @@ set -g @tmux-dotbar-maximized-icon "󰊓"
 set -g @tmux-dotbar-show-maximized-icon-for-all-tabs false
 set -g @tmux-dotbar-bold-status false
 set -g @tmux-dotbar-bold-current-window false
+set -g @tmux-dotbar-rounded false
 set -g @tmux-dotbar-ssh-enabled true
 set -g @tmux-dotbar-ssh-icon '󰌘'
 set -g @tmux-dotbar-ssh-icon-only false

--- a/README.md
+++ b/README.md
@@ -68,12 +68,6 @@ set -g @tmux-dotbar-fg-prefix "#cba6f7"
 
 You can also set `@tmux-dotbar-bold-status` to use bold font in the statusbar, or `@tmux-dotbar-bold-current-window` to use bold font just for the active window.
 
-### Rounded prefix highlight
-When the tmux prefix is pressed, the session indicator highlights. By default the edges are square. To use rounded (powerline) edges instead:
-```
-set -g @tmux-dotbar-rounded true
-```
-
 ### Status bar
 You may feel the right part a bit empty. If you want, there's an option to display the current time there, you can enable it (disabled by default) in your `.tmux.conf`:
 ```
@@ -89,10 +83,13 @@ set -g @tmux-dotbar-position top
 ```
 
 #### Session Indicator
-By default, the session name is displayed on the left with prefix highlight logic. You can move it to the right or change its text:
+By default, the session name is displayed on the left with prefix highlight logic and rounded. You can move it to the right or change its text:
 ```
 # Move session indicator to the right (defaults to "left")
 set -g @tmux-dotbar-session-position "right"
+
+# Style for the session indicator
+set -g @tmux-dotbar-rounded true
 
 # Change the text (default to " #S ") while keeping the prefix highlight logic
 set -g @tmux-dotbar-session-text "[#S]"
@@ -141,7 +138,7 @@ set -g @tmux-dotbar-maximized-icon "󰊓"
 set -g @tmux-dotbar-show-maximized-icon-for-all-tabs false
 set -g @tmux-dotbar-bold-status false
 set -g @tmux-dotbar-bold-current-window false
-set -g @tmux-dotbar-rounded false
+set -g @tmux-dotbar-rounded true
 set -g @tmux-dotbar-ssh-enabled true
 set -g @tmux-dotbar-ssh-icon '󰌘'
 set -g @tmux-dotbar-ssh-icon-only false

--- a/dotbar.tmux
+++ b/dotbar.tmux
@@ -18,6 +18,7 @@ fg_prefix=$(get_tmux_option "@tmux-dotbar-fg-prefix" '#95E6CB')
 # Options
 bold_status=$(get_tmux_option "@tmux-dotbar-bold-status" false)
 bold_current_window=$(get_tmux_option "@tmux-dotbar-bold-current-window" false)
+rounded=$(get_tmux_option "@tmux-dotbar-rounded" false)
 status=$(get_tmux_option "@tmux-dotbar-position" "bottom")
 justify=$(get_tmux_option "@tmux-dotbar-justify" "absolute-centre")
 left_state=$(get_tmux_option "@tmux-dotbar-left" true)
@@ -31,7 +32,15 @@ time_text=$(get_tmux_option "@tmux-dotbar-status-right-text" " %H:%M ")
 bold_attr="bold"
 [ "$bold_status" = true ] && bold_attr="nobold"
 
-session_component="#[bg=$bg,fg=$fg_session]#{?client_prefix,,$session_text}#[bg=$fg_prefix,fg=$bg,$bold_attr]#{?client_prefix,$session_text,}#[bg=$bg,fg=${fg_session}]"
+if [ "$rounded" = "true" ]; then
+  edge_left=$'\ue0b6'
+  edge_right=$'\ue0b4'
+  # Trim 1 char from each side so edge glyphs replace the padding, keeping width stable
+  session_text_inner="${session_text:1:-1}"
+  session_component="#[bg=$bg,fg=$fg_session]#{?client_prefix,#[fg=$fg_prefix]$edge_left,$session_text}#[bg=$fg_prefix,fg=$bg,$bold_attr]#{?client_prefix,$session_text_inner,}#[bg=$bg,fg=${fg_session}]#{?client_prefix,#[fg=$fg_prefix]$edge_right,}"
+else
+  session_component="#[bg=$bg,fg=$fg_session]#{?client_prefix,,$session_text}#[bg=$fg_prefix,fg=$bg,$bold_attr]#{?client_prefix,$session_text,}#[bg=$bg,fg=${fg_session}]"
+fi
 time_component="#[bg=$bg,fg=$fg_session]$time_text#[bg=$bg,fg=${fg_session}]"
 
 # Build Default Status Strings

--- a/dotbar.tmux
+++ b/dotbar.tmux
@@ -18,7 +18,7 @@ fg_prefix=$(get_tmux_option "@tmux-dotbar-fg-prefix" '#95E6CB')
 # Options
 bold_status=$(get_tmux_option "@tmux-dotbar-bold-status" false)
 bold_current_window=$(get_tmux_option "@tmux-dotbar-bold-current-window" false)
-rounded=$(get_tmux_option "@tmux-dotbar-rounded" false)
+rounded=$(get_tmux_option "@tmux-dotbar-rounded" true)
 status=$(get_tmux_option "@tmux-dotbar-position" "bottom")
 justify=$(get_tmux_option "@tmux-dotbar-justify" "absolute-centre")
 left_state=$(get_tmux_option "@tmux-dotbar-left" true)
@@ -33,10 +33,15 @@ bold_attr="bold"
 [ "$bold_status" = true ] && bold_attr="nobold"
 
 if [ "$rounded" = "true" ]; then
-  edge_left=$'\ue0b6'
-  edge_right=$'\ue0b4'
-  # Trim 1 char from each side so edge glyphs replace the padding, keeping width stable
-  session_text_inner="${session_text:1:-1}"
+  edge_left=''
+  edge_right=''
+  # Trim 1 char from each side so edge glyphs replace the padding, keeping width stable.
+  # Bash does not allow negative substring lengths, so compute a safe explicit length.
+  if [ "${#session_text}" -gt 2 ]; then
+    session_text_inner="${session_text:1:${#session_text}-2}"
+  else
+    session_text_inner="$session_text"
+  fi
   session_component="#[bg=$bg,fg=$fg_session]#{?client_prefix,#[fg=$fg_prefix]$edge_left,$session_text}#[bg=$fg_prefix,fg=$bg,$bold_attr]#{?client_prefix,$session_text_inner,}#[bg=$bg,fg=${fg_session}]#{?client_prefix,#[fg=$fg_prefix]$edge_right,}"
 else
   session_component="#[bg=$bg,fg=$fg_session]#{?client_prefix,,$session_text}#[bg=$fg_prefix,fg=$bg,$bold_attr]#{?client_prefix,$session_text,}#[bg=$bg,fg=${fg_session}]"


### PR DESCRIPTION
## Summary

- Adds `@tmux-dotbar-rounded` option (`true`/`false`, default `false`)
- When enabled, uses powerline-style rounded edges (`` / ``) on the session indicator when the tmux prefix is active
- When disabled, behavior is unchanged (square edges)

## Usage

```bash
set -g @tmux-dotbar-rounded true
```

Backward compatible — defaults to `false` so existing configs are unaffected.