### PR TITLE
Add options to control bold font for session indicator and right text independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ set -g @tmux-dotbar-fg-session "#9399b2"
 set -g @tmux-dotbar-fg-prefix "#cba6f7"
 ```
 
-You can also set `@tmux-dotbar-bold-status` to use bold font in the statusbar, or `@tmux-dotbar-bold-current-window` to use bold font just for the active window.
+You can also set `@tmux-dotbar-bold-status` to use bold font in the whole statusbar, or `@tmux-dotbar-bold-current-window` to use bold font just for the active window. To bold only the session indicator or right status text, set `@tmux-dotbar-bold-session` or `@tmux-dotbar-bold-status-right`.
 
 ### Status bar
 You may feel the right part a bit empty. If you want, there's an option to display the current time there, you can enable it (disabled by default) in your `.tmux.conf`:
@@ -138,6 +138,8 @@ set -g @tmux-dotbar-maximized-icon "󰊓"
 set -g @tmux-dotbar-show-maximized-icon-for-all-tabs false
 set -g @tmux-dotbar-bold-status false
 set -g @tmux-dotbar-bold-current-window false
+set -g @tmux-dotbar-bold-session false
+set -g @tmux-dotbar-bold-status-right false
 set -g @tmux-dotbar-rounded true
 set -g @tmux-dotbar-ssh-enabled true
 set -g @tmux-dotbar-ssh-icon '󰌘'

--- a/dotbar.tmux
+++ b/dotbar.tmux
@@ -18,6 +18,8 @@ fg_prefix=$(get_tmux_option "@tmux-dotbar-fg-prefix" '#95E6CB')
 # Options
 bold_status=$(get_tmux_option "@tmux-dotbar-bold-status" false)
 bold_current_window=$(get_tmux_option "@tmux-dotbar-bold-current-window" false)
+bold_session=$(get_tmux_option "@tmux-dotbar-bold-session" false)
+bold_status_right=$(get_tmux_option "@tmux-dotbar-bold-status-right" false)
 rounded=$(get_tmux_option "@tmux-dotbar-rounded" true)
 status=$(get_tmux_option "@tmux-dotbar-position" "bottom")
 justify=$(get_tmux_option "@tmux-dotbar-justify" "absolute-centre")
@@ -29,8 +31,11 @@ session_text=$(get_tmux_option "@tmux-dotbar-session-text" " #S ")
 session_position=$(get_tmux_option "@tmux-dotbar-session-position" "left")
 time_text=$(get_tmux_option "@tmux-dotbar-status-right-text" " %H:%M ")
 
-bold_attr="bold"
-[ "$bold_status" = true ] && bold_attr="nobold"
+session_bold_style=""
+[ "$bold_session" = true ] && session_bold_style=",bold"
+
+status_right_bold_style=""
+[ "$bold_status_right" = true ] && status_right_bold_style=",bold"
 
 if [ "$rounded" = "true" ]; then
   edge_left=''
@@ -42,11 +47,11 @@ if [ "$rounded" = "true" ]; then
   else
     session_text_inner="$session_text"
   fi
-  session_component="#[bg=$bg,fg=$fg_session]#{?client_prefix,#[fg=$fg_prefix]$edge_left,$session_text}#[bg=$fg_prefix,fg=$bg,$bold_attr]#{?client_prefix,$session_text_inner,}#[bg=$bg,fg=${fg_session}]#{?client_prefix,#[fg=$fg_prefix]$edge_right,}"
+  session_component="#[bg=$bg,fg=$fg_session$session_bold_style]#{?client_prefix,#[fg=$fg_prefix]$edge_left,$session_text}#[bg=$fg_prefix,fg=$bg,bold]#{?client_prefix,$session_text_inner,}#[bg=$bg,fg=${fg_session}$session_bold_style]#{?client_prefix,#[fg=$fg_prefix]$edge_right,}"
 else
-  session_component="#[bg=$bg,fg=$fg_session]#{?client_prefix,,$session_text}#[bg=$fg_prefix,fg=$bg,$bold_attr]#{?client_prefix,$session_text,}#[bg=$bg,fg=${fg_session}]"
+  session_component="#[bg=$bg,fg=$fg_session$session_bold_style]#{?client_prefix,,$session_text}#[bg=$fg_prefix,fg=$bg,bold]#{?client_prefix,$session_text,}#[bg=$bg,fg=${fg_session}$session_bold_style]"
 fi
-time_component="#[bg=$bg,fg=$fg_session]$time_text#[bg=$bg,fg=${fg_session}]"
+time_component="#[bg=$bg,fg=$fg_session$status_right_bold_style]$time_text#[bg=$bg,fg=${fg_session}$status_right_bold_style]"
 
 # Build Default Status Strings
 if [ "$session_position" = "right" ]; then


### PR DESCRIPTION
An extension to #5 

```
set -g @tmux-dotbar-bold-session true          # bold the session indicator
set -g @tmux-dotbar-bold-status-right true     # bold the status right text
```
If `@tmux-dotbar-bold-status` is already `true`, these two options will do nothing.

This is useful if you want to bold the session indicator but don't want to bold other windows (I've tried setting bold formatters for the session indicator but prefix indicator doesn't format it well).